### PR TITLE
Replace em dashes with regular hyphens

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,9 +34,9 @@ npm run test:watch   # Run tests in watch mode
   - `toHaveTextContent()` for text inside an element already queried
   - Never use `toBeTruthy()` or `container.innerHTML` for DOM assertions
 - **Queries**: Use user-facing queries (`getByText`, `getByRole`, `getByAltText`). Avoid `getByTestId` unless no semantic query fits. When the same text appears in multiple places, use `within()` to scope queries to a parent element instead of `getAllByText(...)[0]`.
-- **Mindset**: Tests assert what the user experiences, not implementation details. Don't assert CSS class names, internal state, or callback references — assert visible text, presence/absence, and user interactions.
+- **Mindset**: Tests assert what the user experiences, not implementation details. Don't assert CSS class names, internal state, or callback references - assert visible text, presence/absence, and user interactions.
 - **Async**: Prefer `findByText` / `findByRole` over `waitFor(() => expect(...))`. Wait for a user-visible DOM change, then assert synchronously.
-- **Clipboard**: Don't mock `navigator.clipboard`. `userEvent.setup()` provides a built-in clipboard — verify content with `await navigator.clipboard.readText()`.
+- **Clipboard**: Don't mock `navigator.clipboard`. `userEvent.setup()` provides a built-in clipboard - verify content with `await navigator.clipboard.readText()`.
 - **Fake timers + userEvent**: Use `vi.useFakeTimers({ shouldAdvanceTime: true })` and pass `advanceTimers: (ms) => vi.advanceTimersByTime(ms)` to `userEvent.setup()`. Create the user instance per-test via a `setupUser()` helper, not at module level.
 
 ## Code Style
@@ -47,10 +47,11 @@ npm run test:watch   # Run tests in watch mode
 - **Dependencies**: Always use exact versions in package.json (no `^` or `~` prefixes).
 - **Commits**: Conventional commits enforced via commitlint (`feat:`, `fix:`, `build:`, etc.)
 - **Git hooks**: Pre-commit runs `npm run lint`; commit-msg validates conventional commit format
+- **Punctuation**: Never use em dashes (`—`). Use a regular hyphen surrounded by spaces (` - `) instead.
 
 ## Architecture
 
-Dofusdle is a client-side Wordle-style daily guessing game for Dofus Retro 1.29 monsters. No backend — fully static Vite + React 19 SPA.
+Dofusdle is a client-side Wordle-style daily guessing game for Dofus Retro 1.29 monsters. No backend - fully static Vite + React 19 SPA.
 
 ### Core Data Flow
 
@@ -61,14 +62,14 @@ Dofusdle is a client-side Wordle-style daily guessing game for Dofus Retro 1.29 
 ### Component Structure
 
 `Game.tsx` is the main orchestrator under `src/components/DofusRetro/`. It owns all game state (guesses, win status, stats) and delegates to:
-- `SearchBar` — autocomplete input with keyboard navigation
-- `GuessGrid` → `GuessRow` → `AttributeCell` — renders guess results with flip animations
-- `Victory` — win modal with stats and emoji share
+- `SearchBar` - autocomplete input with keyboard navigation
+- `GuessGrid` → `GuessRow` → `AttributeCell` - renders guess results with flip animations
+- `Victory` - win modal with stats and emoji share
 
 Components are organized under `src/components/DofusRetro/` to allow future game modes for other Ankama titles (each would get its own directory).
 
 ### Key Types (`src/types.ts`)
 
-- `Monster` — id, name, type, zone, niveau, couleur, pv, image?
-- `GuessResult` — monster + feedback map of `AttributeFeedback` (value, status, arrow)
-- `GameStats` / `DailyProgress` — localStorage-persisted structures
+- `Monster` - id, name, type, zone, niveau, couleur, pv, image?
+- `GuessResult` - monster + feedback map of `AttributeFeedback` (value, status, arrow)
+- `GameStats` / `DailyProgress` - localStorage-persisted structures

--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@ After each guess, you get feedback on **5 attributes**:
 |-----------|----------|
 | **Ecosystem** | 🟩 Correct or 🟥 Wrong |
 | **Race** | 🟩 Correct or 🟥 Wrong |
-| **Max Level** | 🟩 Exact, 🟧 Within ±10, or 🟥 Far off — with ↑/↓ arrows |
+| **Max Level** | 🟩 Exact, 🟧 Within ±10, or 🟥 Far off - with ↑/↓ arrows |
 | **Color** | 🟩 Exact, 🟧 Partially matching, or 🟥 No match |
-| **Max HP** | 🟩 Exact, 🟧 Within ±20%, or 🟥 Far off — with ↑/↓ arrows |
+| **Max HP** | 🟩 Exact, 🟧 Within ±20%, or 🟥 Far off - with ↑/↓ arrows |
 
 Stuck? After a few wrong guesses, **hints** unlock progressively: the monster's image preview and its ecosystem name.
 
@@ -36,14 +36,14 @@ The puzzle resets every day at **midnight Paris time**.
 ## ✨ Features
 
 - **605 monsters** from the Dofus Retro 1.29 bestiary
-- **Deterministic daily puzzle** — same monster for all players, powered by a seeded PRNG with a 30-day anti-repeat window
+- **Deterministic daily puzzle** - same monster for all players, powered by a seeded PRNG with a 30-day anti-repeat window
 - **Fuzzy search** with autocomplete and monster images
 - **Progressive hints** to help you narrow it down
-- **Stats tracking** — win rate, current streak, max streak, and guess distribution persisted in localStorage
-- **Emoji share** — copy your result grid to share with friends without spoilers
+- **Stats tracking** - win rate, current streak, max streak, and guess distribution persisted in localStorage
+- **Emoji share** - copy your result grid to share with friends without spoilers
 - **Yesterday's answer** displayed after the first guess
-- **Fully client-side** — no backend, no accounts, no tracking. Just a static SPA.
-- **Mobile-friendly** — responsive layout that works on any screen size
+- **Fully client-side** - no backend, no accounts, no tracking. Just a static SPA.
+- **Mobile-friendly** - responsive layout that works on any screen size
 
 ## 🛠 Tech Stack
 
@@ -56,7 +56,7 @@ The puzzle resets every day at **midnight Paris time**.
 | **Search** | fzf (fuzzy finder) |
 | **Effects** | canvas-confetti |
 
-No backend. No database. Fully static — deploy anywhere.
+No backend. No database. Fully static - deploy anywhere.
 
 ## 💻 Development
 
@@ -122,7 +122,7 @@ src/
 <details>
 <summary><strong>Why only Dofus Retro 1.29?</strong></summary>
 
-Dofus Retro has a well-defined, stable bestiary that doesn't change frequently — perfect for a daily guessing game. The component structure is organized under `DofusRetro/` to allow future game modes for other Ankama titles.
+Dofus Retro has a well-defined, stable bestiary that doesn't change frequently - perfect for a daily guessing game. The component structure is organized under `DofusRetro/` to allow future game modes for other Ankama titles.
 
 </details>
 
@@ -142,6 +142,6 @@ Everything stays in your browser's localStorage. No data is sent to any server. 
 
 ## 🙏 Credits
 
-- **[Ankama](https://www.ankama.com/)** — Dofus is their creation. This project is a fan-made tribute, not affiliated with Ankama.
-- **[solomonk.fr](https://solomonk.fr/)** and **[wiki-dofus.eu](https://wiki-dofus.eu/)** — Monster data sources.
+- **[Ankama](https://www.ankama.com/)** - Dofus is their creation. This project is a fan-made tribute, not affiliated with Ankama.
+- **[solomonk.fr](https://solomonk.fr/)** and **[wiki-dofus.eu](https://wiki-dofus.eu/)** - Monster data sources.
 - Inspired by [Wordle](https://www.nytimes.com/games/wordle) and [LoLdle](https://loldle.net/).

--- a/src/components/DofusRetro/__tests__/Header.test.tsx
+++ b/src/components/DofusRetro/__tests__/Header.test.tsx
@@ -34,7 +34,7 @@ describe("Header", () => {
 		it("should display the game subtitle when rendered", () => {
 			renderHeader();
 			expect(
-				screen.getByText("Dofus Retro 1.29 — Devine le monstre du jour"),
+				screen.getByText("Dofus Retro 1.29 - Devine le monstre du jour"),
 			).toBeVisible();
 		});
 

--- a/src/components/DofusRetro/__tests__/HintPanel.test.tsx
+++ b/src/components/DofusRetro/__tests__/HintPanel.test.tsx
@@ -36,7 +36,7 @@ describe("HintPanel", () => {
 		});
 	});
 
-	describe("hint 1 — locked state", () => {
+	describe("hint 1 - locked state", () => {
 		it("should show hint 1 as locked when fewer than 5 guesses have been made", () => {
 			renderPanel({ guessCount: 2 });
 			expect(screen.getByText("dans 3 essais")).toBeVisible();
@@ -53,7 +53,7 @@ describe("HintPanel", () => {
 		});
 	});
 
-	describe("hint 1 — unlocked state", () => {
+	describe("hint 1 - unlocked state", () => {
 		it("should show hint 1 as unlockable when exactly 5 guesses have been made", () => {
 			renderPanel({ guessCount: 5 });
 			const buttons = screen.getAllByText("Cliquer pour révéler");
@@ -67,7 +67,7 @@ describe("HintPanel", () => {
 		});
 	});
 
-	describe("hint 1 — revealed state", () => {
+	describe("hint 1 - revealed state", () => {
 		it("should reveal hint 1 blurred image when reveal button is clicked", async () => {
 			const onRevealHint1 = vi.fn();
 			renderPanel({ guessCount: 5, onRevealHint1 });
@@ -87,7 +87,7 @@ describe("HintPanel", () => {
 		});
 	});
 
-	describe("hint 2 — locked state", () => {
+	describe("hint 2 - locked state", () => {
 		it("should show hint 2 as locked when fewer than 8 guesses have been made", () => {
 			renderPanel({ guessCount: 5 });
 			expect(screen.getByText("dans 3 essais")).toBeVisible();
@@ -104,7 +104,7 @@ describe("HintPanel", () => {
 		});
 	});
 
-	describe("hint 2 — unlocked state", () => {
+	describe("hint 2 - unlocked state", () => {
 		it("should show hint 2 as unlockable when exactly 8 guesses have been made", () => {
 			renderPanel({ guessCount: 8 });
 			const hint2Button = screen
@@ -124,7 +124,7 @@ describe("HintPanel", () => {
 		});
 	});
 
-	describe("hint 2 — revealed state", () => {
+	describe("hint 2 - revealed state", () => {
 		it("should reveal hint 2 ecosystem text when reveal button is clicked", async () => {
 			const onRevealHint2 = vi.fn();
 			renderPanel({ guessCount: 8, hint1Revealed: true, onRevealHint2 });

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -43,7 +43,7 @@ export default function Header({ stats }: Props) {
 				</a>
 			</h1>
 			<p className={styles.subtitle}>
-				Dofus Retro 1.29 — Devine le monstre du jour
+				Dofus Retro 1.29 - Devine le monstre du jour
 			</p>
 			<nav className={styles.toolbar}>
 				<button
@@ -212,14 +212,14 @@ export default function Header({ stats }: Props) {
 						</p>
 						<ul>
 							<li>
-								<span className="legend-correct">🟩 Vert</span> — Attribut exact
+								<span className="legend-correct">🟩 Vert</span> - Attribut exact
 							</li>
 							<li>
-								<span className="legend-partial">🟧 Orange</span> — Proche
+								<span className="legend-partial">🟧 Orange</span> - Proche
 								(valeur presque correcte)
 							</li>
 							<li>
-								<span className="legend-wrong">🟥 Rouge</span> — Pas de
+								<span className="legend-wrong">🟥 Rouge</span> - Pas de
 								correspondance
 							</li>
 							<li>
@@ -246,7 +246,7 @@ export default function Header({ stats }: Props) {
 								>
 									<path d="M12 4l-8 8h5v8h6v-8h5z" fill="currentColor" />
 								</svg>{" "}
-								— Le vrai monstre est plus haut / plus bas
+								- Le vrai monstre est plus haut / plus bas
 							</li>
 						</ul>
 						<p>

--- a/src/utils/__tests__/compare.test.ts
+++ b/src/utils/__tests__/compare.test.ts
@@ -232,7 +232,7 @@ describe("compareMonsters", () => {
 		it("should display dash for couleur value when guess color is empty", () => {
 			const guess = monster({ couleur: "" });
 			const target = monster();
-			expect(compareMonsters(guess, target).feedback.couleur.value).toBe("—");
+			expect(compareMonsters(guess, target).feedback.couleur.value).toBe("-");
 		});
 	});
 });

--- a/src/utils/compare.ts
+++ b/src/utils/compare.ts
@@ -72,7 +72,7 @@ export function compareMonsters(guess: Monster, target: Monster): GuessResult {
 				arrow: niveauResult.arrow,
 			},
 			couleur: {
-				value: guess.couleur || "—",
+				value: guess.couleur || "-",
 				status: compareCouleur(guess.couleur, target.couleur),
 				arrow: null,
 			},


### PR DESCRIPTION
## Summary
- Replace all em dashes (`—`) with regular hyphens (` - `) across UI text, source code, tests, and documentation
- Add a punctuation rule to CLAUDE.md forbidding em dashes going forward

## Test plan
- [x] All 185 tests pass
- [ ] Verify UI text renders correctly in the browser