### PR TITLE
feat: add flip animation to hint cards on reveal

### DIFF
--- a/src/components/DofusRetro/HintPanel.module.css
+++ b/src/components/DofusRetro/HintPanel.module.css
@@ -36,7 +36,9 @@
 	border: 2px solid var(--border);
 	background: var(--bg-card);
 	text-align: center;
-	min-height: 100px;
+	height: 164px;
+	box-sizing: border-box;
+	overflow: hidden;
 }
 
 .slotLocked {
@@ -61,7 +63,14 @@
 .slotRevealed {
 	border-color: var(--accent);
 	background: rgba(212, 152, 60, 0.1);
-	animation: fadeIn 0.3s ease;
+}
+
+.flipOut {
+	animation: hintFlipOut 0.3s ease forwards;
+}
+
+.flipIn {
+	animation: hintFlipIn 0.4s ease both;
 }
 
 .icon {
@@ -124,10 +133,35 @@
 	}
 }
 
+@keyframes hintFlipOut {
+	0% {
+		transform: perspective(800px) rotateY(0deg);
+		opacity: 1;
+	}
+	100% {
+		transform: perspective(800px) rotateY(90deg);
+		opacity: 0;
+	}
+}
+
+@keyframes hintFlipIn {
+	0% {
+		transform: perspective(800px) rotateY(-90deg);
+		opacity: 0;
+	}
+	50% {
+		opacity: 1;
+	}
+	100% {
+		transform: perspective(800px) rotateY(0deg);
+		opacity: 1;
+	}
+}
+
 @media (max-width: 600px) {
 	.slot {
 		padding: 10px 6px;
-		min-height: 80px;
+		height: 124px;
 	}
 
 	.icon {

--- a/src/components/DofusRetro/HintPanel.tsx
+++ b/src/components/DofusRetro/HintPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import styles from "./HintPanel.module.css";
 
 function BlurredImage({ src }: { src: string }) {
@@ -50,6 +50,7 @@ interface Props {
 
 const HINT1_THRESHOLD = 5;
 const HINT2_THRESHOLD = 8;
+const FLIP_OUT_MS = 300;
 
 export default function HintPanel({
 	guessCount,
@@ -61,6 +62,11 @@ export default function HintPanel({
 	onRevealHint1,
 	onRevealHint2,
 }: Props) {
+	const [flipping1, setFlipping1] = useState(false);
+	const [flipping2, setFlipping2] = useState(false);
+	const [justRevealed1, setJustRevealed1] = useState(false);
+	const [justRevealed2, setJustRevealed2] = useState(false);
+
 	if (won) return null;
 
 	const hint1Unlocked = guessCount >= HINT1_THRESHOLD;
@@ -68,12 +74,33 @@ export default function HintPanel({
 	const hint1Remaining = HINT1_THRESHOLD - guessCount;
 	const hint2Remaining = HINT2_THRESHOLD - guessCount;
 
+	function handleFlipHint1() {
+		setFlipping1(true);
+		setTimeout(() => {
+			setFlipping1(false);
+			setJustRevealed1(true);
+			onRevealHint1();
+		}, FLIP_OUT_MS);
+	}
+
+	function handleFlipHint2() {
+		setFlipping2(true);
+		setTimeout(() => {
+			setFlipping2(false);
+			setJustRevealed2(true);
+			onRevealHint2();
+		}, FLIP_OUT_MS);
+	}
+
 	return (
 		<div className={styles.panel}>
 			<h3 className={styles.title}>Indices</h3>
 			<div className={styles.slots}>
-				{hint1Revealed ? (
-					<div className={`${styles.slot} ${styles.slotRevealed}`}>
+				{hint1Revealed || justRevealed1 ? (
+					<div
+						className={`${styles.slot} ${styles.slotRevealed} ${justRevealed1 ? styles.flipIn : ""}`}
+						onAnimationEnd={() => setJustRevealed1(false)}
+					>
 						{targetImage ? (
 							<div className={styles.blurredContainer}>
 								<BlurredImage src={targetImage} />
@@ -86,8 +113,9 @@ export default function HintPanel({
 				) : hint1Unlocked ? (
 					<button
 						type="button"
-						className={`${styles.slot} ${styles.slotUnlocked}`}
-						onClick={onRevealHint1}
+						className={`${styles.slot} ${styles.slotUnlocked} ${flipping1 ? styles.flipOut : ""}`}
+						onClick={handleFlipHint1}
+						disabled={flipping1}
 					>
 						<svg
 							aria-hidden="true"
@@ -132,16 +160,20 @@ export default function HintPanel({
 					</div>
 				)}
 
-				{hint2Revealed ? (
-					<div className={`${styles.slot} ${styles.slotRevealed}`}>
+				{hint2Revealed || justRevealed2 ? (
+					<div
+						className={`${styles.slot} ${styles.slotRevealed} ${justRevealed2 ? styles.flipIn : ""}`}
+						onAnimationEnd={() => setJustRevealed2(false)}
+					>
 						<span className={styles.slotValue}>{targetEcosystem}</span>
 						<span className={styles.slotLabel}>Ecosystème</span>
 					</div>
 				) : hint2Unlocked ? (
 					<button
 						type="button"
-						className={`${styles.slot} ${styles.slotUnlocked}`}
-						onClick={onRevealHint2}
+						className={`${styles.slot} ${styles.slotUnlocked} ${flipping2 ? styles.flipOut : ""}`}
+						onClick={handleFlipHint2}
+						disabled={flipping2}
 					>
 						<svg
 							aria-hidden="true"

--- a/src/components/DofusRetro/__tests__/Game.test.tsx
+++ b/src/components/DofusRetro/__tests__/Game.test.tsx
@@ -178,7 +178,7 @@ describe("Game", () => {
 				hint1Revealed: true,
 			});
 			render(<GameWrapper />);
-			expect(screen.getByAltText("Indice visuel")).toBeVisible();
+			expect(screen.getByRole("img", { name: "Indice visuel" })).toBeVisible();
 		});
 	});
 

--- a/src/components/DofusRetro/__tests__/HintPanel.test.tsx
+++ b/src/components/DofusRetro/__tests__/HintPanel.test.tsx
@@ -69,13 +69,19 @@ describe("HintPanel", () => {
 
 	describe("hint 1 - revealed state", () => {
 		it("should reveal hint 1 blurred image when reveal button is clicked", async () => {
+			vi.useFakeTimers({ shouldAdvanceTime: true });
+			const user = userEvent.setup({
+				advanceTimers: (ms) => vi.advanceTimersByTime(ms),
+			});
 			const onRevealHint1 = vi.fn();
 			renderPanel({ guessCount: 5, onRevealHint1 });
 
 			const buttons = screen.getAllByText("Cliquer pour révéler");
-			await userEvent.click(buttons[0]);
+			await user.click(buttons[0]);
+			await vi.advanceTimersByTimeAsync(300);
 
 			expect(onRevealHint1).toHaveBeenCalledOnce();
+			vi.useRealTimers();
 		});
 
 		it('should show "Aucune image" when hint 1 is revealed but monster has no image', () => {
@@ -126,12 +132,18 @@ describe("HintPanel", () => {
 
 	describe("hint 2 - revealed state", () => {
 		it("should reveal hint 2 ecosystem text when reveal button is clicked", async () => {
+			vi.useFakeTimers({ shouldAdvanceTime: true });
+			const user = userEvent.setup({
+				advanceTimers: (ms) => vi.advanceTimersByTime(ms),
+			});
 			const onRevealHint2 = vi.fn();
 			renderPanel({ guessCount: 8, hint1Revealed: true, onRevealHint2 });
 
-			await userEvent.click(screen.getByText("Cliquer pour révéler"));
+			await user.click(screen.getByText("Cliquer pour révéler"));
+			await vi.advanceTimersByTimeAsync(300);
 
 			expect(onRevealHint2).toHaveBeenCalledOnce();
+			vi.useRealTimers();
 		});
 	});
 


### PR DESCRIPTION
## Summary
- Hint cards now flip with a 3D animation when revealed (flip-out on the unlocked card, flip-in on the revealed content)
- Fixed card height (164px desktop, 124px mobile) prevents layout shift during the animation
- Already-revealed hints on page reload display instantly without animation

## Test plan
- [ ] Make 5 guesses to unlock hint 1, click reveal - card should flip smoothly
- [ ] Make 8 guesses to unlock hint 2, click reveal - card should flip smoothly
- [ ] Card dimensions should not change during the flip
- [ ] Reload page with hints already revealed - they appear instantly, no animation
- [ ] All 186 tests pass