### PR TITLE
fix: blurred hint image not blurred on iOS (Safari/WebKit)

### DIFF
--- a/src/components/DofusRetro/HintPanel.module.css
+++ b/src/components/DofusRetro/HintPanel.module.css
@@ -113,6 +113,7 @@
 .blurredImage {
 	width: 110px;
 	height: 110px;
+	filter: blur(8px);
 }
 
 @keyframes fadeIn {
@@ -143,5 +144,6 @@
 	.blurredImage {
 		width: 80px;
 		height: 80px;
+		filter: blur(6px);
 	}
 }

--- a/src/components/DofusRetro/HintPanel.tsx
+++ b/src/components/DofusRetro/HintPanel.tsx
@@ -13,7 +13,6 @@ function BlurredImage({ src }: { src: string }) {
 		const img = new Image();
 		img.onload = () => {
 			const padding = canvas.width * 0.1;
-			ctx.filter = "blur(8px)";
 			ctx.drawImage(
 				img,
 				padding,

--- a/src/components/DofusRetro/__tests__/Game.test.tsx
+++ b/src/components/DofusRetro/__tests__/Game.test.tsx
@@ -178,7 +178,7 @@ describe("Game", () => {
 				hint1Revealed: true,
 			});
 			render(<GameWrapper />);
-			expect(screen.getByAltText("Indice visuel")).toBeVisible();
+			expect(screen.getByRole("img", { name: "Indice visuel" })).toBeVisible();
 		});
 	});
 


### PR DESCRIPTION
## Summary

- Replaces `ctx.filter = "blur(8px)"` (unsupported on Safari/WebKit) with CSS `filter: blur()` on the canvas element
- Fixes `getByAltText` → `getByRole("img")` in Game test for canvas element query

Closes #46

## Test plan

- [ ] Verify blurred hint image appears blurred on iOS Safari/Chrome
- [ ] Verify blurred hint image still appears blurred on desktop Chrome/Firefox
- [ ] Verify right-clicking the canvas does not offer "Open image in new tab"
- [ ] Run `npm run test` - all 186 tests pass