### PR TITLE
feat: reset streak when player skips a day

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,16 +5,19 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ## Commands
 
 ```bash
-npm run dev          # Start dev server (http://localhost:5173)
-npm run build        # TypeScript check + Vite production build
-npm run preview      # Preview production build locally
-npm run lint         # Biome lint check
-npm run lint:fix     # Auto-fix lint issues
-npm run format       # Format all files with Biome
-npm run typecheck    # TypeScript check (app + tests)
-npm run test         # Run tests (Vitest)
-npm run test:watch   # Run tests in watch mode
+npm run dev              # Start dev server (http://localhost:5173)
+npm run build            # TypeScript check + Vite build (staging mode, no Sentry)
+npm run build:production # TypeScript check + Vite build (production mode, requires SENTRY_* env vars)
+npm run preview          # Preview production build locally
+npm run lint             # Biome lint check
+npm run lint:fix         # Auto-fix lint issues
+npm run format           # Format all files with Biome
+npm run typecheck        # TypeScript check (app + tests)
+npm run test             # Run tests (Vitest)
+npm run test:watch       # Run tests in watch mode
 ```
+
+`npm run build` is safe to run locally without any env vars. `npm run build:production` is used by Cloudflare Pages and requires `SENTRY_ORG`, `SENTRY_PROJECT`, and `SENTRY_AUTH_TOKEN`.
 
 ## Testing
 

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
 	"type": "module",
 	"scripts": {
 		"dev": "vite",
-		"build": "tsc -b && vite build",
+		"build": "tsc -b && vite build --mode staging",
+		"build:production": "tsc -b && vite build --mode production",
 		"test": "vitest run",
 		"test:watch": "vitest",
 		"lint": "biome check .",

--- a/src/components/DofusRetro/__tests__/Game.test.tsx
+++ b/src/components/DofusRetro/__tests__/Game.test.tsx
@@ -67,6 +67,7 @@ const { bouftou, tofu, arakne, mockStorage, mockConfetti, mockDaily } =
 						currentStreak: 0,
 						maxStreak: 0,
 						guessDistribution: {},
+						lastPlayedDate: null,
 					}),
 				),
 				recordWin: vi.fn(
@@ -76,6 +77,7 @@ const { bouftou, tofu, arakne, mockStorage, mockConfetti, mockDaily } =
 						currentStreak: 1,
 						maxStreak: 1,
 						guessDistribution: { 1: 1 },
+						lastPlayedDate: "2025-6-15",
 					}),
 				),
 				saveTargetMonster: vi.fn(),
@@ -105,6 +107,7 @@ const emptyStats: GameStats = {
 	currentStreak: 0,
 	maxStreak: 0,
 	guessDistribution: {},
+	lastPlayedDate: null,
 };
 
 function GameWrapper({ initialStats }: { initialStats?: GameStats }) {
@@ -138,6 +141,7 @@ beforeEach(() => {
 		currentStreak: 1,
 		maxStreak: 1,
 		guessDistribution: { 1: 1 },
+		lastPlayedDate: "2025-6-15",
 	});
 	mockStorage.loadTargetMonster.mockReturnValue(null);
 });

--- a/src/components/DofusRetro/__tests__/Header.test.tsx
+++ b/src/components/DofusRetro/__tests__/Header.test.tsx
@@ -14,6 +14,7 @@ const defaultStats: GameStats = {
 	currentStreak: 3,
 	maxStreak: 5,
 	guessDistribution: {},
+	lastPlayedDate: null,
 };
 
 function renderHeader(stats: Partial<GameStats> = {}) {

--- a/src/components/DofusRetro/__tests__/Victory.test.tsx
+++ b/src/components/DofusRetro/__tests__/Victory.test.tsx
@@ -31,6 +31,7 @@ const stats: GameStats = {
 	currentStreak: 3,
 	maxStreak: 5,
 	guessDistribution: {},
+	lastPlayedDate: null,
 };
 
 const defaults = {

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,6 +38,7 @@ export interface GameStats {
 	currentStreak: number;
 	maxStreak: number;
 	guessDistribution: Record<number, number>;
+	lastPlayedDate: string | null;
 }
 
 export interface DailyProgress {

--- a/src/utils/__tests__/storage.test.ts
+++ b/src/utils/__tests__/storage.test.ts
@@ -11,6 +11,7 @@ import {
 
 vi.mock("../daily", () => ({
 	getTodayKey: () => "2025-6-15",
+	getYesterdayKey: () => "2025-6-14",
 }));
 
 const PROGRESS_KEY = "dofusdle-progress";
@@ -152,6 +153,7 @@ describe("loadStats", () => {
 			currentStreak: 0,
 			maxStreak: 0,
 			guessDistribution: {},
+			lastPlayedDate: null,
 		});
 	});
 
@@ -175,6 +177,7 @@ describe("loadStats", () => {
 			currentStreak: 0,
 			maxStreak: 0,
 			guessDistribution: {},
+			lastPlayedDate: null,
 		});
 	});
 });
@@ -233,5 +236,55 @@ describe("recordWin", () => {
 		expect(raw.gamesPlayed).toBe(1);
 		expect(raw.gamesWon).toBe(1);
 		expect(raw.guessDistribution[4]).toBe(1);
+	});
+
+	it("should reset currentStreak to 1 when the player skipped a day", () => {
+		localStorage.setItem(
+			STATS_KEY,
+			JSON.stringify({
+				gamesPlayed: 5,
+				gamesWon: 5,
+				currentStreak: 5,
+				maxStreak: 5,
+				guessDistribution: {},
+				lastPlayedDate: "2025-6-10",
+			}),
+		);
+		const stats = recordWin(3);
+		expect(stats.currentStreak).toBe(1);
+		expect(stats.maxStreak).toBe(5);
+	});
+
+	it("should continue the streak when the player played yesterday", () => {
+		localStorage.setItem(
+			STATS_KEY,
+			JSON.stringify({
+				gamesPlayed: 3,
+				gamesWon: 3,
+				currentStreak: 3,
+				maxStreak: 3,
+				guessDistribution: {},
+				lastPlayedDate: "2025-6-14",
+			}),
+		);
+		const stats = recordWin(2);
+		expect(stats.currentStreak).toBe(4);
+		expect(stats.maxStreak).toBe(4);
+	});
+
+	it("should not reset the streak when lastPlayedDate is missing (migration)", () => {
+		localStorage.setItem(
+			STATS_KEY,
+			JSON.stringify({
+				gamesPlayed: 10,
+				gamesWon: 10,
+				currentStreak: 10,
+				maxStreak: 10,
+				guessDistribution: {},
+			}),
+		);
+		const stats = recordWin(1);
+		expect(stats.currentStreak).toBe(11);
+		expect(stats.maxStreak).toBe(11);
 	});
 });

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -1,5 +1,5 @@
 import type { DailyProgress, GameStats } from "../types";
-import { getTodayKey } from "./daily";
+import { getTodayKey, getYesterdayKey } from "./daily";
 
 const PROGRESS_KEY = "dofusdle-progress";
 const STATS_KEY = "dofusdle-stats";
@@ -11,6 +11,7 @@ function defaultStats(): GameStats {
 		currentStreak: 0,
 		maxStreak: 0,
 		guessDistribution: {},
+		lastPlayedDate: null,
 	};
 }
 
@@ -87,6 +88,15 @@ export function getWinPercentage(stats: GameStats): number {
 
 export function recordWin(guessCount: number): GameStats {
 	const stats = loadStats();
+	const today = getTodayKey();
+	const yesterday = getYesterdayKey();
+	if (
+		stats.lastPlayedDate &&
+		stats.lastPlayedDate !== yesterday &&
+		stats.lastPlayedDate !== today
+	) {
+		stats.currentStreak = 0;
+	}
 	stats.gamesPlayed += 1;
 	stats.gamesWon += 1;
 	stats.currentStreak += 1;
@@ -95,6 +105,7 @@ export function recordWin(guessCount: number): GameStats {
 	}
 	stats.guessDistribution[guessCount] =
 		(stats.guessDistribution[guessCount] || 0) + 1;
+	stats.lastPlayedDate = today;
 	saveStats(stats);
 	return stats;
 }


### PR DESCRIPTION
## Summary

- Track `lastPlayedDate` in `GameStats` to detect skipped days
- Reset `currentStreak` to 0 before incrementing when the previous win was neither yesterday nor today
- Backward-compatible: existing users without `lastPlayedDate` keep their streak on first win after the update
- Split build scripts: `npm run build` (staging, no Sentry) and `npm run build:production` (requires `SENTRY_*` env vars)

## Test plan

- [x] `npm run typecheck` passes
- [x] `npm run test` passes (192 tests, 3 new streak tests)
- [x] `npm run build` succeeds locally without Sentry env vars
- [ ] Verify Cloudflare Pages build command is updated to `npm run build:production`