### PR TITLE
feat: show banner when all attributes match but wrong monster

### DIFF
--- a/src/components/DofusRetro/FeedbackBanner.module.css
+++ b/src/components/DofusRetro/FeedbackBanner.module.css
@@ -1,0 +1,56 @@
+.banner {
+	position: fixed;
+	bottom: 24px;
+	left: 50%;
+	transform: translateX(-50%);
+	background: var(--bg-secondary);
+	border: 1px solid var(--correct);
+	border-radius: 12px;
+	padding: 12px 40px 12px 16px;
+	max-width: 400px;
+	width: 90%;
+	z-index: 50;
+	animation: slideUp 0.3s ease;
+}
+
+.message {
+	font-size: 0.9rem;
+	color: var(--text-primary);
+	line-height: 1.4;
+}
+
+.closeBtn {
+	position: absolute;
+	top: 8px;
+	right: 8px;
+	width: 28px;
+	height: 28px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: transparent;
+	border: none;
+	color: var(--text-secondary);
+	font-size: 1rem;
+	cursor: pointer;
+	border-radius: 50%;
+	transition:
+		color 0.2s,
+		background 0.2s;
+}
+
+.closeBtn:hover {
+	color: var(--text-primary);
+	background: var(--highlight);
+}
+
+@keyframes slideUp {
+	from {
+		opacity: 0;
+		transform: translateX(-50%) translateY(16px);
+	}
+	to {
+		opacity: 1;
+		transform: translateX(-50%) translateY(0);
+	}
+}

--- a/src/components/DofusRetro/FeedbackBanner.tsx
+++ b/src/components/DofusRetro/FeedbackBanner.tsx
@@ -1,0 +1,35 @@
+import { useEffect } from "react";
+import styles from "./FeedbackBanner.module.css";
+
+interface Props {
+	visible: boolean;
+	onDismiss: () => void;
+}
+
+const AUTO_DISMISS_MS = 5_000;
+
+export default function FeedbackBanner({ visible, onDismiss }: Props) {
+	useEffect(() => {
+		if (!visible) return;
+		const id = setTimeout(onDismiss, AUTO_DISMISS_MS);
+		return () => clearTimeout(id);
+	}, [visible, onDismiss]);
+
+	if (!visible) return null;
+
+	return (
+		<div className={styles.banner} role="alert">
+			<p className={styles.message}>
+				Tous les attributs correspondent, mais ce n'est pas le bon monstre !
+			</p>
+			<button
+				type="button"
+				className={styles.closeBtn}
+				onClick={onDismiss}
+				aria-label="Fermer"
+			>
+				&#x2715;
+			</button>
+		</div>
+	);
+}

--- a/src/components/DofusRetro/Game.tsx
+++ b/src/components/DofusRetro/Game.tsx
@@ -18,6 +18,7 @@ import {
 	saveTargetMonster,
 } from "../../utils/storage";
 import ColorLegend from "./ColorLegend";
+import FeedbackBanner from "./FeedbackBanner";
 import styles from "./Game.module.css";
 import GuessGrid from "./GuessGrid";
 import HintPanel from "./HintPanel";
@@ -59,6 +60,7 @@ export default function Game({ stats, onStatsChange }: Props) {
 	const [victoryShownOnce, setVictoryShownOnce] = useState(false);
 	const [animatingRowIndex, setAnimatingRowIndex] = useState(-1);
 	const [hints, setHints] = useState({ hint1: false, hint2: false });
+	const [showAllCorrectBanner, setShowAllCorrectBanner] = useState(false);
 
 	const resetForNewDay = useCallback((newKey: string) => {
 		setDateKey(newKey);
@@ -160,6 +162,13 @@ export default function Game({ stats, onStatsChange }: Props) {
 				setShowVictory(true);
 				setVictoryShownOnce(true);
 			}, VICTORY_MODAL_DELAY_MS);
+		} else {
+			const allCorrect = Object.values(result.feedback).every(
+				(attr) => attr.status === "correct",
+			);
+			if (allCorrect) {
+				setTimeout(() => setShowAllCorrectBanner(true), CONFETTI_FIRST_MS);
+			}
 		}
 
 		if (!devMode) {
@@ -237,6 +246,10 @@ export default function Game({ stats, onStatsChange }: Props) {
 				disabled={won}
 			/>
 			<GuessGrid results={results} animatingRowIndex={animatingRowIndex} />
+			<FeedbackBanner
+				visible={showAllCorrectBanner}
+				onDismiss={() => setShowAllCorrectBanner(false)}
+			/>
 			{results.length > 0 && !won && <ColorLegend />}
 			{won && !showVictory && victoryShownOnce && (
 				<button

--- a/src/components/DofusRetro/__tests__/FeedbackBanner.test.tsx
+++ b/src/components/DofusRetro/__tests__/FeedbackBanner.test.tsx
@@ -1,0 +1,58 @@
+// @vitest-environment jsdom
+import "@testing-library/jest-dom/vitest";
+import { act, cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import FeedbackBanner from "../FeedbackBanner";
+
+beforeEach(() => {
+	vi.useFakeTimers({ shouldAdvanceTime: true });
+});
+
+afterEach(() => {
+	cleanup();
+	vi.useRealTimers();
+});
+
+function setupUser() {
+	return userEvent.setup({
+		advanceTimers: (ms) => vi.advanceTimersByTime(ms),
+	});
+}
+
+describe("FeedbackBanner", () => {
+	it("should display feedback message when visible", () => {
+		render(<FeedbackBanner visible={true} onDismiss={vi.fn()} />);
+		expect(
+			screen.getByText(
+				"Tous les attributs correspondent, mais ce n'est pas le bon monstre !",
+			),
+		).toBeVisible();
+	});
+
+	it("should not render when not visible", () => {
+		render(<FeedbackBanner visible={false} onDismiss={vi.fn()} />);
+		expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+	});
+
+	it("should dismiss when close button is clicked", async () => {
+		const user = setupUser();
+		const onDismiss = vi.fn();
+		render(<FeedbackBanner visible={true} onDismiss={onDismiss} />);
+		await user.click(screen.getByRole("button", { name: "Fermer" }));
+		expect(onDismiss).toHaveBeenCalledOnce();
+	});
+
+	it("should auto-dismiss after 5 seconds when visible", () => {
+		const onDismiss = vi.fn();
+		render(<FeedbackBanner visible={true} onDismiss={onDismiss} />);
+		expect(onDismiss).not.toHaveBeenCalled();
+		act(() => vi.advanceTimersByTime(5000));
+		expect(onDismiss).toHaveBeenCalledOnce();
+	});
+
+	it("should have alert role for accessibility when visible", () => {
+		render(<FeedbackBanner visible={true} onDismiss={vi.fn()} />);
+		expect(screen.getByRole("alert")).toBeVisible();
+	});
+});

--- a/src/components/DofusRetro/__tests__/Game.test.tsx
+++ b/src/components/DofusRetro/__tests__/Game.test.tsx
@@ -7,92 +7,112 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { DailyProgress, GameStats } from "../../../types";
 import Game from "../Game";
 
-const { bouftou, tofu, arakne, mockStorage, mockConfetti, mockDaily } =
-	vi.hoisted(() => {
-		const bouftou = {
-			id: 1,
-			name: "Bouftou",
-			ecosystem: "Plaines de Cania",
-			race: "Bouftous",
-			niveau_min: 1,
-			niveau_max: 10,
-			pv_min: 10,
-			pv_max: 50,
-			couleur: "Orange",
-			image: "/img/monsters/1.svg",
-			availableFrom: "2025-1-1",
-		};
-		const tofu = {
-			id: 2,
-			name: "Tofu",
-			ecosystem: "Forêt d'Amakna",
-			race: "Tofus",
-			niveau_min: 1,
-			niveau_max: 5,
-			pv_min: 5,
-			pv_max: 20,
-			couleur: "Bleu",
-			image: "/img/monsters/2.svg",
-			availableFrom: "2025-1-1",
-		};
-		const arakne = {
-			id: 3,
-			name: "Arakne",
-			ecosystem: "Bois de Litneg",
-			race: "Araknes",
-			niveau_min: 1,
-			niveau_max: 4,
-			pv_min: 4,
-			pv_max: 16,
-			couleur: "Vert",
-			availableFrom: "2025-1-1",
-		};
-		return {
-			bouftou,
-			tofu,
-			arakne,
-			mockDaily: {
-				getDailyMonster: vi.fn(),
-				getYesterdayMonster: vi.fn(),
-				getTodayKey: vi.fn(),
-				getYesterdayKey: vi.fn(),
-			},
-			mockStorage: {
-				loadProgress: vi.fn((): DailyProgress | null => null),
-				saveProgress: vi.fn(),
-				loadStats: vi.fn(
-					(): GameStats => ({
-						gamesPlayed: 0,
-						gamesWon: 0,
-						currentStreak: 0,
-						maxStreak: 0,
-						guessDistribution: {},
-						lastPlayedDate: null,
-					}),
-				),
-				recordWin: vi.fn(
-					(): GameStats => ({
-						gamesPlayed: 1,
-						gamesWon: 1,
-						currentStreak: 1,
-						maxStreak: 1,
-						guessDistribution: { 1: 1 },
-						lastPlayedDate: "2025-6-15",
-					}),
-				),
-				saveTargetMonster: vi.fn(),
-				loadTargetMonster: vi.fn((): number | null => null),
-				getWinPercentage: (stats: GameStats) =>
-					stats.gamesPlayed > 0
-						? Math.round((stats.gamesWon / stats.gamesPlayed) * 100)
-						: 0,
-			},
-			mockConfetti: vi.fn(),
-		};
-	});
+const {
+	bouftou,
+	bouftouRoyal,
+	tofu,
+	arakne,
+	mockStorage,
+	mockConfetti,
+	mockDaily,
+} = vi.hoisted(() => {
+	const bouftou = {
+		id: 1,
+		name: "Bouftou",
+		ecosystem: "Plaines de Cania",
+		race: "Bouftous",
+		niveau_min: 1,
+		niveau_max: 10,
+		pv_min: 10,
+		pv_max: 50,
+		couleur: "Orange",
+		image: "/img/monsters/1.svg",
+		availableFrom: "2025-1-1",
+	};
+	const bouftouRoyal = {
+		id: 99,
+		name: "Bouftou Royal",
+		ecosystem: "Plaines de Cania",
+		race: "Bouftous",
+		niveau_min: 1,
+		niveau_max: 10,
+		pv_min: 10,
+		pv_max: 50,
+		couleur: "Orange",
+		availableFrom: "2025-1-1",
+	};
+	const tofu = {
+		id: 2,
+		name: "Tofu",
+		ecosystem: "Forêt d'Amakna",
+		race: "Tofus",
+		niveau_min: 1,
+		niveau_max: 5,
+		pv_min: 5,
+		pv_max: 20,
+		couleur: "Bleu",
+		image: "/img/monsters/2.svg",
+		availableFrom: "2025-1-1",
+	};
+	const arakne = {
+		id: 3,
+		name: "Arakne",
+		ecosystem: "Bois de Litneg",
+		race: "Araknes",
+		niveau_min: 1,
+		niveau_max: 4,
+		pv_min: 4,
+		pv_max: 16,
+		couleur: "Vert",
+		availableFrom: "2025-1-1",
+	};
+	return {
+		bouftou,
+		bouftouRoyal,
+		tofu,
+		arakne,
+		mockDaily: {
+			getDailyMonster: vi.fn(),
+			getYesterdayMonster: vi.fn(),
+			getTodayKey: vi.fn(),
+			getYesterdayKey: vi.fn(),
+		},
+		mockStorage: {
+			loadProgress: vi.fn((): DailyProgress | null => null),
+			saveProgress: vi.fn(),
+			loadStats: vi.fn(
+				(): GameStats => ({
+					gamesPlayed: 0,
+					gamesWon: 0,
+					currentStreak: 0,
+					maxStreak: 0,
+					guessDistribution: {},
+					lastPlayedDate: null,
+				}),
+			),
+			recordWin: vi.fn(
+				(): GameStats => ({
+					gamesPlayed: 1,
+					gamesWon: 1,
+					currentStreak: 1,
+					maxStreak: 1,
+					guessDistribution: { 1: 1 },
+					lastPlayedDate: "2025-6-15",
+				}),
+			),
+			saveTargetMonster: vi.fn(),
+			loadTargetMonster: vi.fn((): number | null => null),
+			getWinPercentage: (stats: GameStats) =>
+				stats.gamesPlayed > 0
+					? Math.round((stats.gamesWon / stats.gamesPlayed) * 100)
+					: 0,
+		},
+		mockConfetti: vi.fn(),
+	};
+});
 
 vi.mock("../../../data/monsters.json", () => ({
-	default: [bouftou, tofu, arakne],
+	default: [bouftou, bouftouRoyal, tofu, arakne],
 }));
 
 vi.mock("../../../utils/daily", () => mockDaily);
@@ -349,6 +369,44 @@ describe("Game", () => {
 
 			expect(
 				screen.queryByText("Tofu", { selector: "[class*='monsterName'] span" }),
+			).not.toBeInTheDocument();
+		});
+	});
+
+	describe("all-correct banner", () => {
+		it("should show all-correct banner when guess matches all attributes but is wrong monster", async () => {
+			const user = setupUser();
+			render(<GameWrapper />);
+			await guessMonster(user, "Bouftou Royal");
+			act(() => vi.advanceTimersByTime(1200));
+			expect(
+				screen.getByText(
+					"Tous les attributs correspondent, mais ce n'est pas le bon monstre !",
+				),
+			).toBeVisible();
+		});
+
+		it("should not show all-correct banner when guess wins the game", async () => {
+			const user = setupUser();
+			render(<GameWrapper />);
+			await guessMonster(user, "Bouftou");
+			act(() => vi.advanceTimersByTime(1200));
+			expect(
+				screen.queryByText(
+					"Tous les attributs correspondent, mais ce n'est pas le bon monstre !",
+				),
+			).not.toBeInTheDocument();
+		});
+
+		it("should not show all-correct banner when guess has partial or wrong attributes", async () => {
+			const user = setupUser();
+			render(<GameWrapper />);
+			await guessMonster(user, "Tofu");
+			act(() => vi.advanceTimersByTime(1200));
+			expect(
+				screen.queryByText(
+					"Tous les attributs correspondent, mais ce n'est pas le bon monstre !",
+				),
 			).not.toBeInTheDocument();
 		});
 	});


### PR DESCRIPTION
## Summary
- Add a `FeedbackBanner` component that alerts the player when all 5 attributes are correct but the guessed monster is not the target
- Banner auto-dismisses after 5 seconds and can be manually closed
- Includes unit tests for `FeedbackBanner` and integration tests in `Game.test.tsx`

Closes #49

## Test plan
- [ ] Guess a monster with all matching attributes but different name - banner should appear
- [ ] Banner disappears after 5 seconds
- [ ] Clicking close button dismisses the banner
- [ ] Winning guess does not show the banner
- [ ] Guess with partial/wrong attributes does not show the banner