### PR TITLE
refactor: extract useHints and useVictoryModal hooks from Game.tsx

### DIFF
--- a/src/components/DofusRetro/hooks/useHints.ts
+++ b/src/components/DofusRetro/hooks/useHints.ts
@@ -1,0 +1,33 @@
+import { useCallback, useState } from "react";
+
+export function useHints() {
+	const [hints, setHints] = useState({ hint1: false, hint2: false });
+
+	const revealHint1 = useCallback(() => {
+		setHints((h) => ({ ...h, hint1: true }));
+	}, []);
+
+	const revealHint2 = useCallback(() => {
+		setHints((h) => ({ ...h, hint2: true }));
+	}, []);
+
+	const resetHints = useCallback(() => {
+		setHints({ hint1: false, hint2: false });
+	}, []);
+
+	const setRestoredHints = useCallback((hint1: boolean, hint2: boolean) => {
+		setHints({ hint1, hint2 });
+	}, []);
+
+	const hintsUsed = (hints.hint1 ? 1 : 0) + (hints.hint2 ? 1 : 0);
+
+	return {
+		hint1: hints.hint1,
+		hint2: hints.hint2,
+		hintsUsed,
+		revealHint1,
+		revealHint2,
+		resetHints,
+		setRestoredHints,
+	};
+}

--- a/src/components/DofusRetro/hooks/useVictoryModal.ts
+++ b/src/components/DofusRetro/hooks/useVictoryModal.ts
@@ -1,0 +1,65 @@
+import confetti from "canvas-confetti";
+import { useCallback, useState } from "react";
+
+/** Delay before first confetti burst (after last cell finishes flipping). */
+export const CONFETTI_FIRST_MS = 1200;
+/** Delay before second, smaller confetti burst. */
+const CONFETTI_SECOND_MS = 1700;
+/** Delay before showing the victory modal. */
+const VICTORY_MODAL_DELAY_MS = 2000;
+
+interface UseVictoryModalReturn {
+	showVictory: boolean;
+	victoryShownOnce: boolean;
+	triggerWin: () => void;
+	closeVictory: () => void;
+	reopenVictory: () => void;
+	showImmediately: () => void;
+	resetVictory: () => void;
+}
+
+export function useVictoryModal(): UseVictoryModalReturn {
+	const [showVictory, setShowVictory] = useState(false);
+	const [victoryShownOnce, setVictoryShownOnce] = useState(false);
+
+	const triggerWin = useCallback(() => {
+		setTimeout(() => {
+			confetti({ particleCount: 150, spread: 80, origin: { y: 0.6 } });
+		}, CONFETTI_FIRST_MS);
+		setTimeout(() => {
+			confetti({ particleCount: 80, spread: 60, origin: { y: 0.5 } });
+		}, CONFETTI_SECOND_MS);
+		setTimeout(() => {
+			setShowVictory(true);
+			setVictoryShownOnce(true);
+		}, VICTORY_MODAL_DELAY_MS);
+	}, []);
+
+	const closeVictory = useCallback(() => {
+		setShowVictory(false);
+	}, []);
+
+	const reopenVictory = useCallback(() => {
+		setShowVictory(true);
+	}, []);
+
+	const showImmediately = useCallback(() => {
+		setShowVictory(true);
+		setVictoryShownOnce(true);
+	}, []);
+
+	const resetVictory = useCallback(() => {
+		setShowVictory(false);
+		setVictoryShownOnce(false);
+	}, []);
+
+	return {
+		showVictory,
+		victoryShownOnce,
+		triggerWin,
+		closeVictory,
+		reopenVictory,
+		showImmediately,
+		resetVictory,
+	};
+}


### PR DESCRIPTION
## Summary
- Extract hint state management into a `useHints()` hook (`hooks/useHints.ts`)
- Extract victory modal timing and confetti logic into a `useVictoryModal()` hook (`hooks/useVictoryModal.ts`)
- Consolidate 3 duplicated `saveProgress` calls into a single `persistProgress` helper with hint overrides
- Reduce Game.tsx from 11 to 6 state variables, moving animation delay constants to the hook that uses them

Closes #29

## Test plan
- [x] All 202 existing tests pass without modification
- [x] TypeScript compiles cleanly
- [x] Biome lint passes
- [x] Development build succeeds
- [ ] Manual testing: guess flow, hint reveals, victory modal, day-change reset, dev mode