### PR TITLE
fix: add production env vars to wrangler.toml

### DIFF
--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,6 +1,15 @@
 name = "dofusdle"
-compatibility_date = "2025-01-01"
+compatibility_date = "2026-02-11"
 pages_build_output_dir = "dist"
+
+[env.production.vars]
+SENTRY_ORG = "mlz11"
+SENTRY_PROJECT = "dofusdle"
+VITE_SENTRY_DSN = "https://42681133ca4c6a57c3faa0b5772d9254@o4510897575362560.ingest.de.sentry.io/4510897576869968"
+
+[[env.production.kv_namespaces]]
+id = "b124dcd877b743139b0cf12728493a60"
+binding = "SOLVE_COUNTS"
 
 [[kv_namespaces]]
 binding = "SOLVE_COUNTS"


### PR DESCRIPTION
## Summary
- Cloudflare Pages ignores dashboard environment variables (non-encrypted) when a `wrangler.toml` is present, causing the build to fail with `Error: SENTRY_ORG is required`
- Add `[env.production.vars]` with `SENTRY_ORG`, `SENTRY_PROJECT`, and `VITE_SENTRY_DSN` so they are available during production builds
- Add `[[env.production.kv_namespaces]]` for the SOLVE_COUNTS binding in production
- Bump `compatibility_date` to `2026-02-11`

`SENTRY_AUTH_TOKEN` remains as an encrypted secret in the Cloudflare dashboard (not exported to config).

## Test plan
- [ ] Verify Cloudflare Pages production deployment succeeds without `SENTRY_ORG is required` error
- [ ] Verify the site loads correctly after deployment
- [ ] Verify solve counter still works (KV binding)