### PR TITLE
feat: replace blurred image hint with ecosystem and race hints

### DIFF
--- a/src/components/DofusRetro/Game.tsx
+++ b/src/components/DofusRetro/Game.tsx
@@ -284,8 +284,8 @@ export default function Game({ gameMode, stats, onStatsChange }: Props) {
 				won={won}
 				hint1Revealed={hint1}
 				hint2Revealed={hint2}
-				targetImage={target.image}
 				targetEcosystem={target.ecosystem}
+				targetRace={target.race}
 				onRevealHint1={handleRevealHint1}
 				onRevealHint2={handleRevealHint2}
 			/>

--- a/src/components/DofusRetro/HintPanel.module.css
+++ b/src/components/DofusRetro/HintPanel.module.css
@@ -108,23 +108,6 @@
 	color: var(--accent);
 }
 
-.blurredContainer {
-	width: 110px;
-	height: 110px;
-	border-radius: 50%;
-	overflow: hidden;
-	display: flex;
-	align-items: center;
-	justify-content: center;
-	background: var(--bg-primary);
-}
-
-.blurredImage {
-	width: 110px;
-	height: 110px;
-	filter: blur(8px);
-}
-
 @keyframes fadeIn {
 	from {
 		opacity: 0;
@@ -168,16 +151,5 @@
 	.icon {
 		width: 22px;
 		height: 22px;
-	}
-
-	.blurredContainer {
-		width: 80px;
-		height: 80px;
-	}
-
-	.blurredImage {
-		width: 80px;
-		height: 80px;
-		filter: blur(6px);
 	}
 }

--- a/src/components/DofusRetro/HintPanel.tsx
+++ b/src/components/DofusRetro/HintPanel.tsx
@@ -1,48 +1,13 @@
-import { useEffect, useRef, useState } from "react";
+import { useState } from "react";
 import styles from "./HintPanel.module.css";
-
-function BlurredImage({ src }: { src: string }) {
-	const canvasRef = useRef<HTMLCanvasElement>(null);
-
-	useEffect(() => {
-		const canvas = canvasRef.current;
-		if (!canvas) return;
-		const ctx = canvas.getContext("2d");
-		if (!ctx) return;
-
-		const img = new Image();
-		img.onload = () => {
-			const padding = canvas.width * 0.1;
-			ctx.drawImage(
-				img,
-				padding,
-				padding,
-				canvas.width - padding * 2,
-				canvas.height - padding * 2,
-			);
-		};
-		img.src = src;
-	}, [src]);
-
-	return (
-		<canvas
-			ref={canvasRef}
-			width={110}
-			height={110}
-			className={styles.blurredImage}
-			role="img"
-			aria-label="Indice visuel"
-		/>
-	);
-}
 
 interface Props {
 	guessCount: number;
 	won: boolean;
 	hint1Revealed: boolean;
 	hint2Revealed: boolean;
-	targetImage: string;
 	targetEcosystem: string;
+	targetRace: string;
 	onRevealHint1: () => void;
 	onRevealHint2: () => void;
 }
@@ -56,8 +21,8 @@ export default function HintPanel({
 	won,
 	hint1Revealed,
 	hint2Revealed,
-	targetImage,
 	targetEcosystem,
+	targetRace,
 	onRevealHint1,
 	onRevealHint2,
 }: Props) {
@@ -100,14 +65,8 @@ export default function HintPanel({
 						className={`${styles.slot} ${styles.slotRevealed} ${justRevealed1 ? styles.flipIn : ""}`}
 						onAnimationEnd={() => setJustRevealed1(false)}
 					>
-						{targetImage ? (
-							<div className={styles.blurredContainer}>
-								<BlurredImage src={targetImage} />
-							</div>
-						) : (
-							<span className={styles.slotLabel}>Aucune image</span>
-						)}
-						<span className={styles.slotLabel}>Image floue</span>
+						<span className={styles.slotValue}>{targetEcosystem}</span>
+						<span className={styles.slotLabel}>Ecosystème</span>
 					</div>
 				) : hint1Unlocked ? (
 					<button
@@ -115,64 +74,6 @@ export default function HintPanel({
 						className={`${styles.slot} ${styles.slotUnlocked} ${flipping1 ? styles.flipOut : ""}`}
 						onClick={handleFlipHint1}
 						disabled={flipping1}
-					>
-						<svg
-							aria-hidden="true"
-							className={styles.icon}
-							width="28"
-							height="28"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							strokeWidth="2"
-							strokeLinecap="round"
-							strokeLinejoin="round"
-						>
-							<rect x="3" y="3" width="18" height="18" rx="2" ry="2" />
-							<circle cx="8.5" cy="8.5" r="1.5" />
-							<path d="M21 15l-5-5L5 21" />
-						</svg>
-						<span className={styles.slotLabel}>Image floue</span>
-						<span className={styles.action}>Cliquer pour révéler</span>
-					</button>
-				) : (
-					<div className={`${styles.slot} ${styles.slotLocked}`}>
-						<svg
-							aria-hidden="true"
-							className={styles.icon}
-							width="28"
-							height="28"
-							viewBox="0 0 24 24"
-							fill="none"
-							stroke="currentColor"
-							strokeWidth="2"
-							strokeLinecap="round"
-							strokeLinejoin="round"
-						>
-							<rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
-							<path d="M7 11V7a5 5 0 0 1 10 0v4" />
-						</svg>
-						<span className={styles.slotLabel}>Image floue</span>
-						<span className={styles.remaining}>
-							dans {hint1Remaining} essai{hint1Remaining > 1 ? "s" : ""}
-						</span>
-					</div>
-				)}
-
-				{hint2Revealed || justRevealed2 ? (
-					<div
-						className={`${styles.slot} ${styles.slotRevealed} ${justRevealed2 ? styles.flipIn : ""}`}
-						onAnimationEnd={() => setJustRevealed2(false)}
-					>
-						<span className={styles.slotValue}>{targetEcosystem}</span>
-						<span className={styles.slotLabel}>Ecosystème</span>
-					</div>
-				) : hint2Unlocked ? (
-					<button
-						type="button"
-						className={`${styles.slot} ${styles.slotUnlocked} ${flipping2 ? styles.flipOut : ""}`}
-						onClick={handleFlipHint2}
-						disabled={flipping2}
 					>
 						<svg
 							aria-hidden="true"
@@ -211,6 +112,65 @@ export default function HintPanel({
 							<path d="M7 11V7a5 5 0 0 1 10 0v4" />
 						</svg>
 						<span className={styles.slotLabel}>Ecosystème</span>
+						<span className={styles.remaining}>
+							dans {hint1Remaining} essai{hint1Remaining > 1 ? "s" : ""}
+						</span>
+					</div>
+				)}
+
+				{hint2Revealed || justRevealed2 ? (
+					<div
+						className={`${styles.slot} ${styles.slotRevealed} ${justRevealed2 ? styles.flipIn : ""}`}
+						onAnimationEnd={() => setJustRevealed2(false)}
+					>
+						<span className={styles.slotValue}>{targetRace}</span>
+						<span className={styles.slotLabel}>Race</span>
+					</div>
+				) : hint2Unlocked ? (
+					<button
+						type="button"
+						className={`${styles.slot} ${styles.slotUnlocked} ${flipping2 ? styles.flipOut : ""}`}
+						onClick={handleFlipHint2}
+						disabled={flipping2}
+					>
+						<svg
+							aria-hidden="true"
+							className={styles.icon}
+							width="28"
+							height="28"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+						>
+							<path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2" />
+							<circle cx="9" cy="7" r="4" />
+							<path d="M23 21v-2a4 4 0 0 0-3-3.87" />
+							<path d="M16 3.13a4 4 0 0 1 0 7.75" />
+						</svg>
+						<span className={styles.slotLabel}>Race</span>
+						<span className={styles.action}>Cliquer pour révéler</span>
+					</button>
+				) : (
+					<div className={`${styles.slot} ${styles.slotLocked}`}>
+						<svg
+							aria-hidden="true"
+							className={styles.icon}
+							width="28"
+							height="28"
+							viewBox="0 0 24 24"
+							fill="none"
+							stroke="currentColor"
+							strokeWidth="2"
+							strokeLinecap="round"
+							strokeLinejoin="round"
+						>
+							<rect x="3" y="11" width="18" height="11" rx="2" ry="2" />
+							<path d="M7 11V7a5 5 0 0 1 10 0v4" />
+						</svg>
+						<span className={styles.slotLabel}>Race</span>
 						<span className={styles.remaining}>
 							dans {hint2Remaining} essai{hint2Remaining > 1 ? "s" : ""}
 						</span>

--- a/src/components/DofusRetro/__tests__/Game.test.tsx
+++ b/src/components/DofusRetro/__tests__/Game.test.tsx
@@ -204,7 +204,7 @@ describe("Game", () => {
 				hint1Revealed: true,
 			});
 			render(<GameWrapper />);
-			expect(screen.getByRole("img", { name: "Indice visuel" })).toBeVisible();
+			expect(screen.getByText("Plaines de Cania")).toBeVisible();
 		});
 	});
 

--- a/src/components/DofusRetro/__tests__/HintPanel.test.tsx
+++ b/src/components/DofusRetro/__tests__/HintPanel.test.tsx
@@ -12,8 +12,8 @@ const defaults = {
 	won: false,
 	hint1Revealed: false,
 	hint2Revealed: false,
-	targetImage: "/img/monsters/42.svg",
 	targetEcosystem: "Créatures des champs",
+	targetRace: "Plantes des champs",
 	onRevealHint1: vi.fn(),
 	onRevealHint2: vi.fn(),
 };
@@ -68,7 +68,7 @@ describe("HintPanel", () => {
 	});
 
 	describe("hint 1 - revealed state", () => {
-		it("should reveal hint 1 blurred image when reveal button is clicked", async () => {
+		it("should reveal hint 1 ecosystem text when reveal button is clicked", async () => {
 			vi.useFakeTimers({ shouldAdvanceTime: true });
 			const user = userEvent.setup({
 				advanceTimers: (ms) => vi.advanceTimersByTime(ms),
@@ -82,6 +82,11 @@ describe("HintPanel", () => {
 
 			expect(onRevealHint1).toHaveBeenCalledOnce();
 			vi.useRealTimers();
+		});
+
+		it("should show ecosystem text when hint 1 is revealed", () => {
+			renderPanel({ hint1Revealed: true });
+			expect(screen.getByText("Créatures des champs")).toBeVisible();
 		});
 	});
 
@@ -107,7 +112,7 @@ describe("HintPanel", () => {
 			renderPanel({ guessCount: 8 });
 			const hint2Button = screen
 				.getAllByRole("button")
-				.find((btn) => btn.textContent?.includes("Ecosystème"));
+				.find((btn) => btn.textContent?.includes("Race"));
 			expect(hint2Button).toBeVisible();
 			expect(hint2Button).toHaveTextContent("Cliquer pour révéler");
 		});
@@ -116,14 +121,14 @@ describe("HintPanel", () => {
 			renderPanel({ guessCount: 10 });
 			const hint2Button = screen
 				.getAllByRole("button")
-				.find((btn) => btn.textContent?.includes("Ecosystème"));
+				.find((btn) => btn.textContent?.includes("Race"));
 			expect(hint2Button).toBeVisible();
 			expect(hint2Button).toHaveTextContent("Cliquer pour révéler");
 		});
 	});
 
 	describe("hint 2 - revealed state", () => {
-		it("should reveal hint 2 ecosystem text when reveal button is clicked", async () => {
+		it("should reveal hint 2 race text when reveal button is clicked", async () => {
 			vi.useFakeTimers({ shouldAdvanceTime: true });
 			const user = userEvent.setup({
 				advanceTimers: (ms) => vi.advanceTimersByTime(ms),
@@ -137,6 +142,11 @@ describe("HintPanel", () => {
 			expect(onRevealHint2).toHaveBeenCalledOnce();
 			vi.useRealTimers();
 		});
+
+		it("should show race text when hint 2 is revealed", () => {
+			renderPanel({ hint2Revealed: true });
+			expect(screen.getByText("Plantes des champs")).toBeVisible();
+		});
 	});
 
 	describe("independent hint states", () => {
@@ -144,9 +154,8 @@ describe("HintPanel", () => {
 			renderPanel({
 				guessCount: 3,
 				hint1Revealed: true,
-				targetImage: "/img/monsters/42.svg",
 			});
-			expect(screen.getByRole("img", { name: "Indice visuel" })).toBeVisible();
+			expect(screen.getByText("Créatures des champs")).toBeVisible();
 			expect(screen.getByText("dans 5 essais")).toBeVisible();
 		});
 


### PR DESCRIPTION
## Summary
- Replaced hint 1 (blurred image) with an ecosystem text hint
- Replaced hint 2 (ecosystem) with a race text hint
- Removed the `BlurredImage` canvas component and associated CSS styles
- Updated icons: hint 1 uses globe icon, hint 2 uses users/group icon

## Test plan
- [x] All 244 existing tests pass
- [x] TypeScript type checking passes
- [x] Biome lint passes
- [ ] Verify hint 1 shows "Ecosystème" label and reveals target ecosystem text after 5 guesses
- [ ] Verify hint 2 shows "Race" label and reveals target race text after 8 guesses
- [ ] Verify flip animations still work correctly for both hints
- [ ] Verify hints persist correctly in localStorage across page reloads

Closes #78