### PR TITLE
Fix theme flash on page refresh for game modes

### DIFF
--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useLayoutEffect, useState } from "react";
 import { Navigate, Route, Routes, useLocation } from "react-router-dom";
 import type { GameMode, GameStats } from "../types";
 import { loadStats } from "../utils/storage";
@@ -27,7 +27,7 @@ function AppContent() {
 	const location = useLocation();
 	const activeMode = MODE_BY_PATH[location.pathname] ?? null;
 
-	useEffect(() => {
+	useLayoutEffect(() => {
 		document.body.classList.toggle(
 			"theme-classique",
 			location.pathname === "/classique",


### PR DESCRIPTION
## Summary
- Add `injectThemeClass` Vite plugin that bakes `theme-classique` / `theme-silhouette` class into `<body>` in prerendered HTML at build time, following the existing `injectRouteMeta` pattern
- Switch `useEffect` to `useLayoutEffect` for the body class toggle so client-side SPA navigation applies the theme before the browser paints

## Test plan
- [ ] Build with `npm run build:development` and verify `dist/classique/index.html` has `<body class="theme-classique">` and `dist/silhouette/index.html` has `<body class="theme-silhouette">`
- [ ] Preview with `npx vite preview --mode development`, win a game in classique or silhouette, refresh the page, and confirm the background and accent colours are correct immediately (no flash of default theme)
- [ ] Navigate between home and game modes via SPA links and confirm theme switches without flash
- [ ] Verify `dist/index.html` still has plain `<body>` (no theme class on home page)