### PR TITLE
fix: prevent sticky logo lift animation on mobile

### DIFF
--- a/src/components/Header.module.css
+++ b/src/components/Header.module.css
@@ -20,8 +20,10 @@
 	transition: transform 0.2s;
 }
 
-.homeLink:hover .logo {
-	transform: translateY(-4px);
+@media (hover: hover) {
+	.homeLink:hover .logo {
+		transform: translateY(-4px);
+	}
 }
 
 .subtitle {


### PR DESCRIPTION
## Summary
- Wraps the logo hover lift effect (`.homeLink:hover .logo`) in a `@media (hover: hover)` query
- Prevents the sticky `:hover` state on touch devices that kept the logo permanently lifted after a tap

## Test plan
- [ ] Open the app on a mobile device (or mobile viewport in dev tools)
- [ ] Tap the logo and verify it no longer stays in the lifted position
- [ ] On desktop, verify the hover lift animation still works as before

Closes #88