### PR TITLE
feat: replace fuzzy search with starts-with matching

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
 			"dependencies": {
 				"@sentry/react": "10.39.0",
 				"canvas-confetti": "1.9.4",
-				"fzf": "0.5.2",
 				"react": "19.2.4",
 				"react-dom": "19.2.4",
 				"react-router": "7.13.1",
@@ -4329,12 +4328,6 @@
 			"engines": {
 				"node": "^8.16.0 || ^10.6.0 || >=11.0.0"
 			}
-		},
-		"node_modules/fzf": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/fzf/-/fzf-0.5.2.tgz",
-			"integrity": "sha512-Tt4kuxLXFKHy8KT40zwsUPUkg1CrsgY25FxA2U/j/0WgEDCk3ddc/zLTCCcbSHX9FcKtLuVaDGtGE/STWC+j3Q==",
-			"license": "BSD-3-Clause"
 		},
 		"node_modules/gensync": {
 			"version": "1.0.0-beta.2",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,6 @@
 	"dependencies": {
 		"@sentry/react": "10.39.0",
 		"canvas-confetti": "1.9.4",
-		"fzf": "0.5.2",
 		"react": "19.2.4",
 		"react-dom": "19.2.4",
 		"react-router": "7.13.1",

--- a/src/components/DofusRetro/SearchBar.tsx
+++ b/src/components/DofusRetro/SearchBar.tsx
@@ -1,5 +1,4 @@
-import { Fzf } from "fzf";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import type { Monster } from "../../types";
 import styles from "./SearchBar.module.css";
 
@@ -41,17 +40,12 @@ export default function SearchBar({
 		.filter((m) => !usedIds.has(m.id))
 		.sort((a, b) => a.name.localeCompare(b.name));
 
-	const fzf = useMemo(
-		() =>
-			new Fzf(available, {
-				selector: (m) => m.name,
-				casing: "case-insensitive",
-			}),
-		[available],
-	);
-
 	const filtered =
-		query.length > 0 ? fzf.find(query).map((r) => r.item) : available;
+		query.length > 0
+			? available.filter((m) =>
+					m.name.toLowerCase().startsWith(query.toLowerCase()),
+				)
+			: available;
 
 	useEffect(() => {
 		setHighlightIndex(0);

--- a/src/components/DofusRetro/__tests__/SearchBar.test.tsx
+++ b/src/components/DofusRetro/__tests__/SearchBar.test.tsx
@@ -49,6 +49,19 @@ const monsters: Monster[] = [
 		image: "/img/monsters/3.svg",
 		availableFrom: "2025-1-1",
 	},
+	{
+		id: 4,
+		name: "Bwork",
+		ecosystem: "Terres de Bwork",
+		race: "Bworks",
+		niveau_min: 5,
+		niveau_max: 15,
+		pv_min: 20,
+		pv_max: 60,
+		couleur: "Vert",
+		image: "/img/monsters/4.svg",
+		availableFrom: "2025-1-1",
+	},
 ];
 
 const defaults = {
@@ -92,7 +105,7 @@ describe("SearchBar", () => {
 			expect(screen.queryAllByRole("listitem")).toHaveLength(0);
 		});
 
-		it("should filter monsters by fuzzy search when typing", async () => {
+		it("should filter monsters by starts-with matching when typing", async () => {
 			renderSearchBar();
 			await userEvent.type(
 				screen.getByPlaceholderText("Devine le monstre..."),
@@ -177,7 +190,7 @@ describe("SearchBar", () => {
 			renderSearchBar();
 			await userEvent.type(
 				screen.getByPlaceholderText("Devine le monstre..."),
-				"o",
+				"b",
 			);
 			const items = screen.getAllByRole("listitem");
 			expect(items[0]).toHaveClass(styles.highlighted);
@@ -187,7 +200,7 @@ describe("SearchBar", () => {
 			renderSearchBar();
 			await userEvent.type(
 				screen.getByPlaceholderText("Devine le monstre..."),
-				"o",
+				"b",
 			);
 			await userEvent.keyboard("{ArrowDown}");
 			const items = screen.getAllByRole("listitem");
@@ -198,7 +211,7 @@ describe("SearchBar", () => {
 			renderSearchBar();
 			await userEvent.type(
 				screen.getByPlaceholderText("Devine le monstre..."),
-				"o",
+				"b",
 			);
 			await userEvent.keyboard("{ArrowDown}{ArrowUp}");
 			const items = screen.getAllByRole("listitem");
@@ -209,7 +222,7 @@ describe("SearchBar", () => {
 			renderSearchBar();
 			await userEvent.type(
 				screen.getByPlaceholderText("Devine le monstre..."),
-				"o",
+				"b",
 			);
 			await userEvent.keyboard("{ArrowUp}");
 			const items = screen.getAllByRole("listitem");
@@ -220,7 +233,7 @@ describe("SearchBar", () => {
 			renderSearchBar();
 			await userEvent.type(
 				screen.getByPlaceholderText("Devine le monstre..."),
-				"o",
+				"b",
 			);
 			const items = screen.getAllByRole("listitem");
 			const lastIndex = items.length - 1;


### PR DESCRIPTION
## Summary
- Replaced `fzf` fuzzy search in SearchBar with a simple case-insensitive `startsWith` filter so typing "bou" only matches monsters whose name begins with "bou" (e.g. "Bouftou"), not unrelated monsters like "Crobak Sombre"
- Removed the `fzf` dependency from `package.json`
- Updated SearchBar tests to reflect starts-with behavior

Closes #91

## Test plan
- [x] All 247 existing tests pass
- [x] TypeScript check passes
- [x] Lint passes
- [ ] Manually verify typing a prefix shows only matching monsters
- [ ] Verify case-insensitive matching (e.g. "BOU", "bou", "Bou" all work)