### PR TITLE
feat: show artwork overlay on mobile game mode cards

### DIFF
--- a/src/components/HomePage.module.css
+++ b/src/components/HomePage.module.css
@@ -182,8 +182,8 @@
 
 	.cardGreen {
 		background: linear-gradient(
-			to bottom,
-			rgba(30, 80, 45, 0.55),
+			to right,
+			rgba(198, 229, 124, 0.5),
 			rgba(26, 23, 37, 0.9)
 		);
 	}
@@ -194,11 +194,7 @@
 		inset: 0;
 		border-radius: 14px;
 		padding: 2px;
-		background: linear-gradient(
-			to bottom,
-			rgba(61, 174, 96, 0.35),
-			rgba(26, 23, 37, 0.9)
-		);
+		background: rgba(198, 229, 124, 0.4);
 		mask:
 			linear-gradient(#fff 0 0) content-box,
 			linear-gradient(#fff 0 0);
@@ -208,8 +204,8 @@
 
 	.cardOrange {
 		background: linear-gradient(
-			to bottom,
-			rgba(120, 55, 15, 0.55),
+			to right,
+			rgba(210, 120, 40, 0.5),
 			rgba(26, 23, 37, 0.9)
 		);
 	}
@@ -220,11 +216,7 @@
 		inset: 0;
 		border-radius: 14px;
 		padding: 2px;
-		background: linear-gradient(
-			to bottom,
-			rgba(210, 120, 40, 0.35),
-			rgba(26, 23, 37, 0.9)
-		);
+		background: rgba(210, 120, 40, 0.4);
 		mask:
 			linear-gradient(#fff 0 0) content-box,
 			linear-gradient(#fff 0 0);


### PR DESCRIPTION
## Summary
- Replace the small 52x52 dofus icon with the large artwork image on mobile game mode cards
- Image fades seamlessly into the card background using mask-image gradients on all four edges
- Card height fixed at 100px for a compact mobile layout

## Test plan
- [ ] Open the homepage on a mobile viewport (< 600px) and verify both cards show artwork with fade effect
- [ ] Verify desktop layout (> 600px) is unaffected
- [ ] Verify gradient borders still render correctly around the full card