### PR TITLE
fix: resolve hydration mismatch and theme loss on page refresh

### DIFF
--- a/index.html
+++ b/index.html
@@ -48,6 +48,11 @@
     <title>Dofusdle - Le jeu de devinettes Dofus Retro</title>
   </head>
   <body>
+    <script>
+      var p=location.pathname;if(p.length>1)p=p.replace(/\/$/,"");
+      if(p==="/classique")document.body.classList.add("theme-classique");
+      else if(p==="/silhouette")document.body.classList.add("theme-silhouette");
+    </script>
     <div id="root"></div>
     <noscript>
       <h1>Dofusdle</h1>

--- a/src/components/Silhouette/SilhouetteImage.tsx
+++ b/src/components/Silhouette/SilhouetteImage.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useCallback, useState } from "react";
 import styles from "./SilhouetteImage.module.css";
 
 interface Props {
@@ -9,12 +9,22 @@ interface Props {
 export default function SilhouetteImage({ src, revealed }: Props) {
 	const [loadedSrc, setLoadedSrc] = useState<string | null>(null);
 
+	const imgRef = useCallback(
+		(img: HTMLImageElement | null) => {
+			if (img?.complete && img.naturalWidth > 0) {
+				setLoadedSrc(src);
+			}
+		},
+		[src],
+	);
+
 	if (!src) return null;
 
 	return (
 		<div className={styles.container}>
 			<div className={styles.frame}>
 				<img
+					ref={imgRef}
 					src={src}
 					alt={revealed ? "Monstre révélé" : "Silhouette du monstre"}
 					className={`${styles.image} ${revealed ? styles.revealed : styles.silhouette}`}

--- a/src/utils/storage.ts
+++ b/src/utils/storage.ts
@@ -14,7 +14,7 @@ function targetKey(mode: GameMode): string {
 	return `dofusdle-target-${mode}`;
 }
 
-function defaultStats(): GameStats {
+export function defaultStats(): GameStats {
 	return {
 		gamesPlayed: 0,
 		gamesWon: 0,


### PR DESCRIPTION
## Summary
- **Issue #96**: Defer `loadStats()` from `useState` initializer to a `useEffect`, so the initial render uses `defaultStats()` (all zeros) matching the prerendered HTML - eliminates React hydration error #418
- **Issue #97**: Normalize `location.pathname` by stripping trailing slashes before matching against `MODE_BY_PATH`, so the theme body class is preserved when wrangler redirects `/classique` → `/classique/`
- Add an inline `<script>` in `index.html` to set the theme class before React loads, preventing a flash of the default background in dev mode

## Root cause
Wrangler (and Cloudflare Pages) issue a 308 redirect from `/classique` to `/classique/`. The `useLayoutEffect` compared `location.pathname` (`"/classique/"`) against `"/classique"` exactly, causing `classList.toggle("theme-classique", false)` to actively **remove** the class that was correctly present in the prerendered HTML.

## Test plan
- [x] `npm run build:development` then `npx wrangler pages dev dist --port 5214`
- [x] Open `/classique` - verify green themed background persists after refresh, no React error #418 in console
- [x] Open `/silhouette` - verify orange themed background persists after refresh
- [x] Seed localStorage with stats, refresh - verify streak updates without hydration errors
- [x] `npm run test` - all 241 tests pass
- [x] `npm run typecheck` - no type errors

Closes #96, closes #97