### PR TITLE
fix: make monster search accent-insensitive

### DIFF
--- a/src/components/DofusRetro/SearchBar.tsx
+++ b/src/components/DofusRetro/SearchBar.tsx
@@ -1,6 +1,10 @@
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { Monster } from "../../types";
 import styles from "./SearchBar.module.css";
+
+function stripDiacritics(s: string): string {
+	return s.normalize("NFD").replace(/[\u0300-\u036f]/g, "");
+}
 
 interface Props {
 	monsters: Monster[];
@@ -40,10 +44,20 @@ export default function SearchBar({
 		.filter((m) => !usedIds.has(m.id))
 		.sort((a, b) => a.name.localeCompare(b.name));
 
+	const normalizedNames = useMemo(
+		() =>
+			new Map(
+				available.map((m) => [m.id, stripDiacritics(m.name.toLowerCase())]),
+			),
+		[available],
+	);
+
 	const filtered =
 		query.length > 0
 			? available.filter((m) =>
-					m.name.toLowerCase().startsWith(query.toLowerCase()),
+					(normalizedNames.get(m.id) ?? "").startsWith(
+						stripDiacritics(query.toLowerCase()),
+					),
 				)
 			: available;
 

--- a/src/components/DofusRetro/__tests__/SearchBar.test.tsx
+++ b/src/components/DofusRetro/__tests__/SearchBar.test.tsx
@@ -62,6 +62,19 @@ const monsters: Monster[] = [
 		image: "/img/monsters/4.svg",
 		availableFrom: "2025-1-1",
 	},
+	{
+		id: 5,
+		name: "Gelée Bleue",
+		ecosystem: "Créatures de la forêt",
+		race: "Gelées",
+		niveau_min: 1,
+		niveau_max: 10,
+		pv_min: 10,
+		pv_max: 40,
+		couleur: "Bleu",
+		image: "/img/monsters/5.svg",
+		availableFrom: "2025-1-1",
+	},
 ];
 
 const defaults = {
@@ -114,6 +127,17 @@ describe("SearchBar", () => {
 			const items = screen.getAllByRole("listitem");
 			expect(items).toHaveLength(1);
 			expect(items[0]).toHaveTextContent("Tofu");
+		});
+
+		it("should match accented monster names when typing without accents", async () => {
+			renderSearchBar();
+			await userEvent.type(
+				screen.getByPlaceholderText("Devine le monstre..."),
+				"gelee",
+			);
+			const items = screen.getAllByRole("listitem");
+			expect(items).toHaveLength(1);
+			expect(items[0]).toHaveTextContent("Gelée Bleue");
 		});
 
 		it("should exclude already-guessed monsters from results", async () => {


### PR DESCRIPTION
## Summary
- Strip diacritics from monster names and search query so users can type without accents (e.g., "gelee" matches "Gelée Bleue")
- Pre-compute normalized names in a `useMemo` map for efficiency
- Add test with accented monster name ("Gelée Bleue")

Closes #101

## Test plan
- [x] Existing SearchBar tests pass (27/27)
- [ ] Manually type "gelee" and verify "Gelée Bleue" appears in dropdown
- [ ] Manually type "crane" and verify "Crâne" variants appear
- [ ] Verify accented input still works (typing "Gelée" matches "Gelée Bleue")