### PR TITLE
fix: extend background to full screen on iOS with safe area insets

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,7 +2,7 @@
 <html lang="fr">
   <head>
     <meta charset="UTF-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
     <meta name="theme-color" content="#1a1725" />
     <link rel="canonical" href="https://dofusdle.fr/" />
     <link rel="preconnect" href="https://o4510897575362560.ingest.de.sentry.io" crossorigin />

--- a/src/styles/app.css
+++ b/src/styles/app.css
@@ -69,6 +69,11 @@ body {
 	background: var(--bg-primary);
 	color: var(--text-primary);
 	min-height: 100vh;
+	padding:
+		env(safe-area-inset-top)
+		env(safe-area-inset-right)
+		env(safe-area-inset-bottom)
+		env(safe-area-inset-left);
 }
 
 body::after {


### PR DESCRIPTION
## Summary
- Add `viewport-fit=cover` to the viewport meta tag so the page renders behind the notch/Dynamic Island and home indicator on iOS
- Add `env(safe-area-inset-*)` padding to `body` to keep content readable while backgrounds extend edge-to-edge
- No impact on desktop or Android — `env()` values resolve to `0px` on devices without safe area insets

## Test plan
- [ ] Verify on iPhone with notch/Dynamic Island in Safari that the background extends to the full screen
- [ ] Verify content (header, search bar, footer) is not obscured by the notch or home indicator
- [ ] Verify no visual change on desktop browsers
- [ ] Verify no visual change on Android Chrome